### PR TITLE
Add youth population visualization to Strengths tab

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,7 @@
 import dash
 from dash import dcc, html
 import dash_bootstrap_components as dbc
+from youth_chart import get_youth_population_chart
 
 app = dash.Dash(__name__, suppress_callback_exceptions=True, external_stylesheets=[dbc.themes.BOOTSTRAP])
 server = app.server
@@ -35,10 +36,10 @@ app.layout = dbc.Container([
         ]),
         dcc.Tab(label='2. Cultural + Economic Strengths', children=[
             html.Br(),
-            html.P("Charts and data visualizations go here."),
-            # Replace below with actual graphs
-            html.Div("📊 Bar charts or maps about youth, innovation, natural resources")
+            html.P("Africa’s greatest asset is its people, especially its youth. A young, dynamic population drives both cultural creativity and future economic power.", className="lead"),
+            dcc.Graph(figure=get_youth_population_chart())
         ]),
+
         dcc.Tab(label='3. Shared Challenges', children=[
             html.Br(),
             html.Div("⚠️ Data on internet access, unemployment, education gaps.")

--- a/assets/youth_population_africa.csv
+++ b/assets/youth_population_africa.csv
@@ -1,0 +1,11 @@
+Country,Youth_Population_15_24_Millions
+Nigeria,45.3
+Ethiopia,23.1
+Egypt,19.2
+DR Congo,17.4
+Tanzania,13.6
+South Africa,10.1
+Kenya,9.6
+Uganda,8.9
+Sudan,8.4
+Ghana,7.7

--- a/youth_chart.py
+++ b/youth_chart.py
@@ -1,0 +1,24 @@
+# youth_chart.py
+
+import pandas as pd
+import plotly.express as px
+import os
+
+def get_youth_population_chart():
+    # Load youth population data from the assets folder
+    data_path = os.path.join("assets", "youth_population_africa.csv")
+    youth_df = pd.read_csv(data_path)
+
+    # Sort and take top 10
+    top10_df = youth_df.sort_values("Youth_Population_15_24_Millions", ascending=False).head(10)
+
+    # Create bar chart
+    fig = px.bar(
+        top10_df,
+        x="Country",
+        y="Youth_Population_15_24_Millions",
+        title="Top 10 African Countries by Youth Population (Ages 15–24)",
+        labels={"Youth_Population_15_24_Millions": "Youth Population (Millions)"},
+        template="plotly_white"
+    )
+    return fig


### PR DESCRIPTION
This pull request adds a bar chart showing the top 10 African countries by youth population (ages 15–24) to the "Cultural + Economic Strengths" tab of the dashboard.

- Reads real data from `assets/youth_population_africa.csv`
- Chart created using Plotly Express in `youth_chart.py`
- Integrated the chart into Tab 2 via `get_youth_population_chart()`

The chart reinforces Africa’s demographic advantage by highlighting the size of its youth population.
